### PR TITLE
Handle directory without trailing slash for xpose.data

### DIFF
--- a/R/read.phi.R
+++ b/R/read.phi.R
@@ -6,7 +6,7 @@ read.phi <-
            ##sim.suffix="sim",
            quiet=TRUE,
            nm7=TRUE,
-           directory="",
+           directory=".",
            ...)
 {
   
@@ -21,7 +21,7 @@ read.phi <-
       cat(paste("runno must be specified if no phi file name is provided\n"))
       return(NULL)
     }
-    filename <- paste(directory,phi.prefix,runno,phi.suffix,sep="")
+    filename <- file.path(directory, paste0(phi.prefix, runno, phi.suffix))
   } else {
     filename <- phi.file
   }

--- a/R/xpose.data.R
+++ b/R/xpose.data.R
@@ -120,7 +120,7 @@ xpose.data <-function(runno,
                       tab.suffix="",
                       sim.suffix="sim",
                       cwres.suffix="",
-                      directory="",
+                      directory=".",
                       quiet=TRUE,
                       table.names=c("sdtab","mutab","patab","catab",
                         "cotab","mytab","extra","xptab","cwtab"),
@@ -142,7 +142,8 @@ xpose.data <-function(runno,
 
   ## Create the table file names to process
   myfun <- function(x,directory,runno,cwres.suffix,sim.suffix,tab.suffix) {
-    paste(directory,x,runno,cwres.suffix,sim.suffix,tab.suffix,sep="")
+    filename <- paste0(x,runno,cwres.suffix,sim.suffix,tab.suffix)
+    file.path(directory, filename)
   }
 
   tab.files   <- sapply(table.names,myfun,directory,runno,cwres.suffix="",sim.suffix="",tab.suffix)


### PR DESCRIPTION
This fix together with UUPharmacometrics/PsN@b62e6dab2f519e81af8f0999eb96a3049bf6b5f0 for PsN will solve the crash from the course.

The problem would only be triggered if a directory was supplied to xpose.data without a slash at the end.